### PR TITLE
Add 'browser' in the text

### DIFF
--- a/templates/download.html
+++ b/templates/download.html
@@ -6,7 +6,7 @@
       </div>
       <h3 class="text-primary">{{ _('Get connected') }}</h3>
       <div class="row pl-3 pr-5 text-tpo">
-              <p class="text-tpo"><span class="text-bold">{{ _('If you are in a country where Tor is blocked, you can configure Tor to connect to a bridge during the setup process.') }} </span></p>
+              <p class="text-tpo"><span class="text-bold">{{ _('If you are in a country where Tor is blocked, you can configure Tor Browser to connect to a bridge during the setup process.') }} </span></p>
               <p class="text-tpo">{{ _('Select "Tor is censored in my country."') }}</p>
       </div>
       <div class="row pl-3 pr-5 text-tpo">


### PR DESCRIPTION
Add "browser" in the phrase:  "you can configure Tor to connect to a bridge during the setup process. "