### PR TITLE
Rename download link to alpha builds

### DIFF
--- a/templates/hero-download.html
+++ b/templates/hero-download.html
@@ -43,7 +43,7 @@
 </div>
 <div class="row p-5">
   <a class="mx-auto text-white py-3 text-center" href="{{ 'languages'|url(alt=this.alt) }}"><u>{{ _('Download in another language or platform') }}</u></a>
-  <a class="mx-auto text-white py-3 text-center" href="{{ 'alpha'|url(alt=this.alt) }}"><u>{{ _('Advanced Install Options') }}</u></a>
+  <a class="mx-auto text-white py-3 text-center" href="{{ 'alpha'|url(alt=this.alt) }}"><u>{{ _('Download the latest alpha build') }}</u></a>
   <a class="mx-auto text-white py-3 text-center" href="{{ 'tor'|url(alt=this.alt) }}"><u>{{ _('Download Tor Source Code') }}</u></a>
 </div>
 <div class="hidden-sm row p-md-5 justify-content-center window-bg">


### PR DESCRIPTION
Changed from "Advanced Install Options" to "Download the latest alpha build"
Ref: https://dip.torproject.org/web/tpo/issues/2