### PR TITLE
Add #tor-www and #tor-l10n to list of irc channels in contact page

### DIFF
--- a/templates/contact.html
+++ b/templates/contact.html
@@ -8,10 +8,12 @@
       <h3 class="text-secondary display-5 mb-4"><i class="text-primary pr-2 fas fa-table-tennis-png"></i> {{ _('Chat with us on') }} {{ render_oftc() }}</h3>
       <p class="text-tpo"><span class="text-primary nick">#tor</span> - {{ _("Ask questions about using Tor.") }}</p>
       <p class="text-tpo"><span class="text-primary nick">#tor-dev</span> - {{ _("Discuss Tor-related coding and protocols. Ideas are welcome.") }}</p>
-      <p class="text-tpo"><span class="text-primary nick">#tor-project</span> - {{ _("Discuss organization and community related topics: meetups, outreach, translation, or website improvements.") }}</p>
+      <p class="text-tpo"><span class="text-primary nick">#tor-l10n</span> - {{ _("Get in touch with other translators") }}</p>
       <p class="text-tpo"><span class="text-primary nick">#tor-meeting</span> - {{ _("Watch or join publicly logged team meetings.") }}</p>
+      <p class="text-tpo"><span class="text-primary nick">#tor-project</span> - {{ _("Discuss organization and community related topics: meetups, outreach, translation, or website improvements.") }}</p>
       <p class="text-tpo"><span class="text-primary nick">#tor-relays</span> - {{ _("Discuss running a Tor relay.") }}</p>
       <p class="text-tpo"><span class="text-primary nick">#tor-south</span> - {{ _("Talk with Tor's global south community.") }}</p>
+      <p class="text-tpo"><span class="text-primary nick">#tor-www</span> - {{ _("Talk with us about our portals.") }}</p>
     </div>
     <div class="d-block d-sm-none container py-3">
       <div class="row border-bottom border-light"><p></p></div>


### PR DESCRIPTION
Also alphabetized the list.
https://dip.torproject.org/web/tpo/issues/28

Suggestion: add other places to see irc / social media channels?
ex: a tab in the about section, community section
So far it's only accessible through the small footer link.

EDIT: Please point me to where to put suggestions. Pretty sure they don't go in PR's.