### PR TITLE
WIP: Migrate Trademark page

### DIFF
--- a/content/about/trademark/trademark-faq/trademark-faq-1/contents.lr
+++ b/content/about/trademark/trademark-faq/trademark-faq-1/contents.lr
@@ -7,4 +7,7 @@ _hidden: yes
 seo_slug: how-to-use-tor-trademark
 ---
 description:
-The Tor Project encourages developers to use the name Tor in ways that do not confuse the public about the source of anonymity software and services. If you are building open-source non-commercial software or services that incorporate or work with The Tor Project's code, you may use the name “Tor” in an accurate description of your work. We ask you to include a link to the official Tor website https://www.torproject.org/ so users can verify the original source of Tor for themselves, and a note indicating that your project is not sponsored by The Tor Project. For example, “This product is produced independently from the Tor® anonymity software and carries no guarantee from The Tor Project about quality, suitability or anything else.”
+The Tor Project encourages developers to use the name Tor in ways that do not confuse the public about the source of anonymity software and services.
+If you are building open-source non-commercial software or services that incorporate or work with The Tor Project's code, you may use the name “Tor” in an accurate description of your work.
+We ask you to include a link to the official Tor website https://www.torproject.org/ so users can verify the original source of Tor for themselves, and a note indicating that your project is not sponsored by The Tor Project.
+For example, “This product is produced independently from the Tor® anonymity software and carries no guarantee from The Tor Project about quality, suitability or anything else.”

--- a/content/about/trademark/trademark-faq/trademark-faq-2/contents.lr
+++ b/content/about/trademark/trademark-faq/trademark-faq-2/contents.lr
@@ -7,4 +7,6 @@ _hidden: yes
 seo_slug: can-I-use-tor-onion-logo
 ---
 description:
-If you're making non-commercial use of Tor software, you may also use the Tor onion logo (as an illustration, not as a brand for your products). Please don't modify the design or colors of the logo. You can use items that look like the Tor onion logo to illustrate a point (e.g. an exploded onion with layers, for instance), so long as they're not used as logos in ways that would confuse people.
+If you're making non-commercial use of Tor software, you may also use the Tor onion logo (as an illustration, not as a brand for your products).
+Please don't modify the design or colors of the logo.
+You can use items that look like the Tor onion logo to illustrate a point (e.g. an exploded onion with layers, for instance), so long as they're not used as logos in ways that would confuse people.

--- a/content/about/trademark/trademark-faq/trademark-faq-3/contents.lr
+++ b/content/about/trademark/trademark-faq/trademark-faq-3/contents.lr
@@ -7,4 +7,7 @@ _hidden: yes
 seo_slug: tor-product-domain-name
 ---
 description:
-Please don't use Tor in your product name or domain name. Instead, find a name that will accurately identify your products or services. Remember that our goal is to make sure that people aren't confused about whether your product or project is made or endorsed by The Tor Project. Creating a new brand that incorporates the Tor brand is likely to lead to confusion, and commercial confusion is a sign of trademark infringement.
+Please don't use Tor in your product name or domain name.
+Instead, find a name that will accurately identify your products or services.
+Remember that our goal is to make sure that people aren't confused about whether your product or project is made or endorsed by The Tor Project.
+Creating a new brand that incorporates the Tor brand is likely to lead to confusion, and commercial confusion is a sign of trademark infringement.

--- a/content/about/trademark/trademark-faq/trademark-faq-4/contents.lr
+++ b/content/about/trademark/trademark-faq/trademark-faq-4/contents.lr
@@ -7,7 +7,9 @@ _hidden: yes
 seo_slug: tor-derived-names
 ---
 description:
-Tor enjoys a vibrant [research community](https://research.torproject.org/) that examines anonymity attacks and defenses, design improvements, impact on society, and so on. We think it's great that professors and other researchers continue to contribute to our community, and we've even gotten funding from the National Science Foundation to help keep the Tor design and code researcher-friendly. The [anonymity bibliography](http://freehaven.net/anonbib/) lists many research papers that use Tor-derived names in their titles: Torsk, DefenestraTor, Tortoise, LASTor, Torchestra, StegoTorus, and more.
+Tor enjoys a vibrant [research community](https://research.torproject.org/) that examines anonymity attacks and defenses, design improvements, impact on society, and so on.
+We think it's great that professors and other researchers continue to contribute to our community, and we've even gotten funding from the National Science Foundation to help keep the Tor design and code researcher-friendly.
+The [anonymity bibliography](http://freehaven.net/anonbib/) lists many research papers that use Tor-derived names in their titles: Torsk, DefenestraTor, Tortoise, LASTor, Torchestra, StegoTorus, and more.
 
 Since the authors of these research papers aren't trying to make a profit from them, and (because they're just papers, not products) the papers aren't confusing Tor users into running potentially unsafe software, we believe that the use of the Tor mark in these research paper titles is acceptable non-trademark or fair use.
 

--- a/content/about/trademark/trademark-faq/trademark-faq-5/contents.lr
+++ b/content/about/trademark/trademark-faq/trademark-faq-5/contents.lr
@@ -7,7 +7,13 @@ _hidden: yes
 seo_slug: enforcing-trademark-rights
 ---
 description:
-The Tor Project is a non-profit corporation organized to research and develop the Tor anonymity software and network. We don't want to be trademark bullies, but we will use trademark to protect the public's ability to recognize Tor Project software. Trademark law helps us to assure that the name is used only in connection with genuine Tor anonymity software and for accurate description of software and services. After all, to protect their anonymity securely, computer users must be able to identify the software they are using, so they can account properly for its strengths and weaknesses. Tor has become well-known as a software package and associated network of onion-routing anonymizing proxies, with online documentation, instructions for strengthening anonymity protection, and warnings that even at this stage it remains experimental software. We work with developers to improve the software and network and actively encourage researchers to document attacks to help us strengthen its anonymity protection further. We distribute the software itself freely, but require correct attribution.
+The Tor Project is a non-profit corporation organized to research and develop the Tor anonymity software and network.
+We don't want to be trademark bullies, but we will use trademark to protect the public's ability to recognize Tor Project software.
+Trademark law helps us to assure that the name is used only in connection with genuine Tor anonymity software and for accurate description of software and services.
+After all, to protect their anonymity securely, computer users must be able to identify the software they are using, so they can account properly for its strengths and weaknesses.
+Tor has become well-known as a software package and associated network of onion-routing anonymizing proxies, with online documentation, instructions for strengthening anonymity protection, and warnings that even at this stage it remains experimental software.
+We work with developers to improve the software and network and actively encourage researchers to document attacks to help us strengthen its anonymity protection further.
+We distribute the software itself freely, but require correct attribution.
 
 We hold two trademarks in the United States:
 


### PR DESCRIPTION
I think this is almost complete. Only a few things are not working quite right yet.

- [x] Permalinks don't always load.
- [x] The 'above scenario' link in `trademark-faq-4` links to the old site. (Dependent on permalinks issue above.)
- [x] When permalinks load, the question is usually obscured by the navigation header.
- [x] There are a bunch of build errors about missing templates for the questions.

will-fix: web/tpo#25