### PR TITLE
add hover underline and tooltip for signature link

### DIFF
--- a/templates/hero-download.html
+++ b/templates/hero-download.html
@@ -30,8 +30,8 @@
           <i class="text-light fab fa-{{ id }}-png"></i>
         </a>
         <a class="btn btn-primary mt-4" href="{{ download_link }}">{{ _('Download for') }} {{ item.label }}</a>
-        <a class="link" href="{{ sig_link }}"><span class="tooltip show"><span class="nick text-white">{{ _('Signature') }}</span><span class="tooltip-text">Right-click to download</span></span></a>
-        <a class="link" href="{{ 'https://support.torproject.org/' + this.alt + '/tbb/how-to-verify-signature/' }}" target="_blank"><i style="font-size:10px;" class="text-light fas fa-question-circle"></i></a>
+        <a class="link" href="{{ sig_link }}" download><span class="nick text-white">{{ _('Signature') }}</span></a>
+        <a class="link" href="{{ 'https://support.torproject.org/' + this.alt + '/tbb/how-to-verify-signature/' }}" target="_blank"><span class="tooltip show" style="display:inline;"><i style="font-size:10px;" class="text-light fas fa-question-circle"></i><span class="tooltip-text">How to verify signature</span></span></a>
       </div>
     </div>
     {% endfor %}

--- a/templates/hero-download.html
+++ b/templates/hero-download.html
@@ -30,7 +30,7 @@
           <i class="text-light fab fa-{{ id }}-png"></i>
         </a>
         <a class="btn btn-primary mt-4" href="{{ download_link }}">{{ _('Download for') }} {{ item.label }}</a>
-        <a class="link" href="{{ sig_link }}"><span class="nick text-white">{{ _('Signature') }}</span></a>
+        <a class="link" href="{{ sig_link }}"><span class="tooltip show"><span class="nick text-white">{{ _('Signature') }}</span><span class="tooltip-text">Right-click to download</span></span></a>
         <a class="link" href="{{ 'https://support.torproject.org/' + this.alt + '/tbb/how-to-verify-signature/' }}" target="_blank"><i style="font-size:10px;" class="text-light fas fa-question-circle"></i></a>
       </div>
     </div>


### PR DESCRIPTION
issue: https://gitlab.torproject.org/tpo/web/tpo/-/issues/64

Added a tooltip under the Signature link that reads "right-click to download" to help users distinguish the link as a link, and also how to download the file

see also: https://github.com/torproject/lego/pull/22 which should be merged simultaneously for the tooltip to display correctly