### PR TITLE
fixed download button redirect to Success page

### DIFF
--- a/templates/hero-download.html
+++ b/templates/hero-download.html
@@ -29,7 +29,7 @@
         <a class="downloadLink" href="{{ download_link }}">
           <i class="text-light fab fa-{{ id }}-png"></i>
         </a>
-        <a class="btn btn-primary mt-4" href="{{ download_link }}">{{ _('Download for') }} {{ item.label }}</a>
+        <a class="btn btn-primary mt-4 downloadLink" href="{{ download_link }}">{{ _('Download for') }} {{ item.label }}</a>
         <a class="link" href="{{ sig_link }}"><span class="nick text-white">{{ _('Signature') }}</span></a>
         <a class="link" href="{{ 'https://support.torproject.org/' + this.alt + '/tbb/how-to-verify-signature/' }}" target="_blank"><i style="font-size:10px;" class="text-light fas fa-question-circle"></i></a>
       </div>


### PR DESCRIPTION
issue: https://gitlab.torproject.org/tpo/web/tpo/-/issues/113

added "downloadLink" to the class of the buttons, enabling the redirect to the Thank You / Success page once a user has clicked the download link. 