### PR TITLE
Fix#173 Added parentheses to Homepage definition 

### DIFF
--- a/content/contents.lr
+++ b/content/contents.lr
@@ -15,5 +15,5 @@ body:
 ###### ABOUT US ######
 
 We believe everyone should be able to explore the internet with privacy.
-We are the Tor Project, a 501(c)3 US nonprofit.
+We are the Tor Project, a 501(c)(3) US nonprofit.
 We advance human rights and defend your privacy online through free software and open networks. [Meet our team](about/people).


### PR DESCRIPTION
Addressing the issue : https://gitlab.torproject.org/tpo/web/support/-/issues/173

Added parentheses in 501(c)3 nonprofit . Now it is 501(c)(3) nonprofit