### PR TITLE
Update download-tor.html

### DIFF
--- a/templates/download-tor.html
+++ b/templates/download-tor.html
@@ -43,7 +43,7 @@
     <table class="table">
       <tbody>
         <tr>
-          <td>{{ _('Windows 10, 8, 7, Vista, XP, 2000, 2003 Server, ME, and Windows 98SE') }}</td>
+          <td>{{ _('Windows 10, 8, 7, and Windows Server (>= 2008)') }}</td>
           <td>{{ _('Contains just Tor and nothing else.') }}</td>
           <td class="text-right">
             {% from "macros/downloads.html" import render_windows_expert %}


### PR DESCRIPTION
Vista, XP, 2000, 2003 Server, ME, and Windows 98SE" are not in conformity with this statement "Supported Windows (>= 7) and Windows Server (>= 2008)" in SupportedPlatforms and needs to be removed since they no longer receive updates from Microsoft, not also supported.