### PR TITLE
Corrected stacking of release panels in press

### DIFF
--- a/templates/macros/press.html
+++ b/templates/macros/press.html
@@ -1,5 +1,5 @@
 {% macro render_release(item, alternative) %}
-<div class="card mx-auto" style="width: 365px; height: 485px;">
+<div class="card mx-xl-auto m-3" style="width: 365px; height: 485px;">
   <img class="card-img-top" src="{{ item.image|asseturl }}" alt="Card image cap">
   <div class="card-body">
     <div class="card-title">

--- a/templates/press.html
+++ b/templates/press.html
@@ -4,7 +4,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-6 py-5">
-        <h4 class="text-secondary mb-4"><i class="text-primary pr-2 fas fa-life-ring-png"></i> {{ _('Get support') }}</h4>
+        <h4 class="text-secondary mb-4"><i class="text-primary pr-2 fas fa-life-ring-png"></i> {{ _('Get Support') }}</h4>
       <div class="row pl-3">
         <a class="h5 text-primary" href="https://support.torproject.org/" title="Tor Project Support Portal" target="_blank">{{ _('Visit our Support Portal') }}</a>
       </div>


### PR DESCRIPTION
Issue: https://gitlab.torproject.org/tpo/web/tpo/-/issues/40#note_2734304
This is the solution for part 1: release panels don't stack very neatly on medium-size screens (and could use some padding between rows on small screens too)
I changed margin settings for the class "card" in press.html(macros)

Also, I capitalized 'S' in "Get support" on the Press page to make it look even with"Brand Assets."