### PR TITLE
Remove "for instance" in Trademark FAQ

### DIFF
--- a/content/about/trademark/trademark-faq/trademark-faq-2/contents.lr
+++ b/content/about/trademark/trademark-faq/trademark-faq-2/contents.lr
@@ -9,4 +9,4 @@ seo_slug: can-I-use-tor-onion-logo
 description:
 If you're making non-commercial use of Tor software, you may also use the Tor onion logo (as an illustration, not as a brand for your products).
 Please don't modify the design or colors of the logo.
-You can use items that look like the Tor onion logo to illustrate a point (e.g. an exploded onion with layers, for instance), so long as they're not used as logos in ways that would confuse people.
+You can use items that look like the Tor onion logo to illustrate a point (e.g. an exploded onion with layers), so long as they're not used as logos in ways that would confuse people.


### PR DESCRIPTION
Previous wording was "e.g. an exploded onion with layers, for instance". But since the sentence already begins "e.g.", the "for instance" is not needed.